### PR TITLE
CUB can now be downloaded from its Gdrive

### DIFF
--- a/dataset/prepare_cub.sh
+++ b/dataset/prepare_cub.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-wget -nc -P dataset/ http://www.vision.caltech.edu/visipedia-data/CUB-200-2011/CUB_200_2011.tgz
+wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1hbzc_P1FuxMkcabkgn9ZKinBwW683j45" -O CUB_200_2011.tgz && rm -rf /tmp/cookies.txt
 wget -nc -O dataset/CUBV2.tar "https://onedrive.live.com/download?cid=B7111B95B80CCC66&resid=B7111B95B80CCC66%2130812&authkey=AFMzb4akufUiWU0"
 mkdir -p dataset/CUB_200_2011
-tar xvf dataset/CUB_200_2011.tgz -C dataset/
+tar xvf CUB_200_2011.tgz -C dataset/
 mv dataset/CUB_200_2011/images dataset/CUB && rm -rf dataset/CUB_200_2011
 tar xvf dataset/CUBV2.tar -C dataset/CUB


### PR DESCRIPTION
Owner of the original CUB dataset moved the dataset to Google drive. This file now has now the link updated so that it can be downloaded directly